### PR TITLE
Update counts in export validations

### DIFF
--- a/src/main/__tests__/services/exportLibrary.test.ts
+++ b/src/main/__tests__/services/exportLibrary.test.ts
@@ -214,7 +214,7 @@ describe('exportLibrary', () => {
     const result = await exportLibrary(1, '/tmp', mockDataSource);
 
     expect(result.success).toBe(false);
-    expect(result.message).toBe('Invalid number of patches found in bank bank01');
+    expect(result.message).toBe('Invalid number of patches found in bank bank01 (expected 16)');
   });
 
   it('should return error if bank content is missing', async () => {

--- a/src/main/services/exportLibrary.ts
+++ b/src/main/services/exportLibrary.ts
@@ -67,8 +67,10 @@ export async function exportLibrary(
       }
 
       // Verify we have the correct number of patches
-      if (patches.length !== 8) {
-        throw new Error(`Invalid number of patches found in bank ${bank.name}`);
+      if (patches.length !== 16) {
+        throw new Error(
+          `Invalid number of patches found in bank ${bank.name} (expected 16)`
+        );
       }
 
       // Export each patch
@@ -95,8 +97,10 @@ export async function exportLibrary(
         const bankSequences = sequences.filter(s => s.bank_id === bank.id);
 
         // Verify we have the correct number of sequences
-        if (bankSequences.length !== 8) {
-          throw new Error(`Invalid number of sequences found in bank ${bank.name}`);
+        if (bankSequences.length !== 16) {
+          throw new Error(
+            `Invalid number of sequences found in bank ${bank.name} (expected 16)`
+          );
         }
 
         // Export each sequence


### PR DESCRIPTION
## Summary
- enforce 16 patches and sequences per bank when exporting
- clarify error messages about expected counts
- update export library test for new error wording

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db45efc2c832697f0212e28b3d0ed