### PR TITLE
Fix lint errors

### DIFF
--- a/src/main/__tests__/services/validateLibrary.test.ts
+++ b/src/main/__tests__/services/validateLibrary.test.ts
@@ -30,7 +30,7 @@ describe('LibraryValidator', () => {
 
     it('should validate a complete and correct library structure', () => {
       // Mock a complete library structure
-      (fs.existsSync as jest.Mock).mockImplementation((path: string) => true);
+      (fs.existsSync as jest.Mock).mockImplementation((_path: string) => true);
       (fs.readdirSync as jest.Mock).mockImplementation((dirPath: string) => {
         if (dirPath === mockLibraryPath) {
           return Array.from({ length: 16 }, (_, i) => `bank${(i + 1).toString().padStart(2, '0')}`);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,6 +1,5 @@
 import { app, BrowserWindow, ipcMain, dialog, Menu, MenuItemConstructorOptions } from 'electron';
 import path from 'path';
-import fs from 'fs';
 import { Repository } from 'typeorm';
 import { importLibrary } from './services/importLibrary';
 import { exportLibrary } from './services/exportLibrary';

--- a/src/main/services/exportLibrary.ts
+++ b/src/main/services/exportLibrary.ts
@@ -5,7 +5,6 @@ import { Library } from '../entities/library.entity';
 import { Bank } from '../entities/bank.entity';
 import { Patch } from '../entities/patch.entity';
 import { PatchSequence } from '../entities/patch-sequence.entity';
-import { padNumber } from '../utils';
 
 interface ExportResult {
   success: boolean;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -259,7 +259,7 @@ const App: React.FC = () => {
             const bank = banks.find(b => b.name === value);
             if (bank) setSelectedBank(bank);
           }}
-          onSlotToggle={(index) => {
+          onSlotToggle={(_index) => {
             // TODO: Implement slot selection logic
           }}
           onConfirm={() => {

--- a/src/renderer/components/CopyToDrawer.tsx
+++ b/src/renderer/components/CopyToDrawer.tsx
@@ -89,8 +89,8 @@ export function CopyToDrawer({
                     slot.occupied && !slot.selected
                       ? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed'
                       : slot.selected
-                      ? 'bg-blue-600 text-white border-blue-500'
-                      : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                        ? 'bg-blue-600 text-white border-blue-500'
+                        : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
                   )}
                 >
                   {slot.index + 1}


### PR DESCRIPTION
## Summary
- fix unused parameter in validation tests
- remove unused variables in main process code
- adjust onSlotToggle handler to silence lint error
- add missing newline in CopyToDrawer

## Testing
- `npm run lint`
- `npm test` *(fails: Test Suites: 3 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684e37cc63b0832687c41d01e975ccf9