### PR TITLE
Import reflect-metadata in main process

### DIFF
--- a/config/jest.setup.js
+++ b/config/jest.setup.js
@@ -1,3 +1,4 @@
+require('reflect-metadata');
 // Mock electron app
 jest.mock('electron', () => ({
   app: {

--- a/src/main/__tests__/main.test.ts
+++ b/src/main/__tests__/main.test.ts
@@ -1,7 +1,10 @@
 jest.mock('fs');
 jest.mock('path');
 
-jest.mock("typeorm", () => ({ Repository: class {} }));
+jest.mock('typeorm', () => {
+  const actual = jest.requireActual('typeorm');
+  return { ...actual, Repository: class {} };
+});
 const handleMock = jest.fn();
 const showOpenDialogMock = jest.fn();
 const showSaveDialogMock = jest.fn();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { app, BrowserWindow, ipcMain, dialog, Menu, MenuItemConstructorOptions } from 'electron';
 import path from 'path';
 import { Repository } from 'typeorm';

--- a/src/main/run-migration.ts
+++ b/src/main/run-migration.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { AppDataSource } from './data-source';
 
 async function runMigration() {


### PR DESCRIPTION
## Summary
- ensure TypeORM decorators work by importing `reflect-metadata`
- load `reflect-metadata` during migrations and jest setup
- adjust `main.test.ts` TypeORM mock to keep decorator functions

## Testing
- `npm test` *(fails: LibraryValidator and renderer tests still failing, but no decorator errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ecdf0d40483269c0f74564ac0e51d