### PR TITLE
Capitalize patch names

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -256,7 +256,7 @@ const App: React.FC = () => {
           <PatchGrid
             patches={patches.map(patch => ({
               id: patch.id.toString(),
-              name: patch.name,
+              name: capitalizeWords(patch.name),
               tags: JSON.parse(patch.tags || '[]'),
               favorited: patch.favorited,
               selected: selectedPatches.has(patch.id.toString())


### PR DESCRIPTION
## Summary
- reuse existing `capitalizeWords` helper to show patch names in title case

## Testing
- `npm run lint`
- `NODE_ENV=test npm test` *(fails: 4 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684ed9d040a083269cb31ce8256c38bc