### PR TITLE
Refactor Patch tags JSON

### DIFF
--- a/src/main/__tests__/renderer/App.test.tsx
+++ b/src/main/__tests__/renderer/App.test.tsx
@@ -37,7 +37,7 @@ describe('App', () => {
         bank_id: 1,
         path: '/path/to/patch1',
         favorited: false,
-        tags: JSON.stringify(['tag1', 'tag2']),
+        tags: ['tag1', 'tag2'],
         library_id: 1,
       },
       {
@@ -47,7 +47,7 @@ describe('App', () => {
         bank_id: 2,
         path: '/path/to/patch2',
         favorited: true,
-        tags: JSON.stringify(['tag3']),
+        tags: ['tag3'],
         library_id: 1,
       },
     ]);
@@ -60,7 +60,7 @@ describe('App', () => {
         bank_id: 1,
         path: '/path/to/patch1',
         favorited: false,
-        tags: JSON.stringify(['tag1', 'tag2']),
+        tags: ['tag1', 'tag2'],
         library_id: 1,
       },
       {
@@ -70,7 +70,7 @@ describe('App', () => {
         bank_id: 2,
         path: '/path/to/patch2',
         favorited: true,
-        tags: JSON.stringify(['tag3']),
+        tags: ['tag3'],
         library_id: 1,
       },
     ]);

--- a/src/main/entities/patch.entity.ts
+++ b/src/main/entities/patch.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, BeforeInsert, BeforeUpdate, AfterLoad } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
 import { Bank } from './bank.entity';
 
 @Entity('patches')
@@ -27,48 +27,11 @@ export class Patch {
   @Column({ type: 'boolean', default: false })
     favorited: boolean;
 
-  @Column({ type: 'text', nullable: true })
-    tags: string;
-
-  // Transient property to hold the parsed tags array
-  private _tagsArray: string[] = [];
-
-  // Getter for tags array
-  get tagsArray(): string[] {
-    return this._tagsArray;
-  }
-
-  // Setter for tags array
-  set tagsArray(value: string[]) {
-    this._tagsArray = value;
-    this.tags = JSON.stringify(value);
-  }
+  @Column('simple-json') // stored as TEXT in SQLite
+    tags: string[];
 
   @ManyToOne(() => Bank, bank => bank.patches)
   @JoinColumn({ name: 'bank_id' })
     bank: Bank;
 
-  // Convert string to array before saving to database
-  @BeforeInsert()
-  @BeforeUpdate()
-  convertTagsToString() {
-    if (this._tagsArray) {
-      this.tags = JSON.stringify(this._tagsArray);
-    }
-  }
-
-  // Convert string to array after loading from database
-  @AfterLoad()
-  convertTagsToArray() {
-    if (this.tags) {
-      try {
-        this._tagsArray = JSON.parse(this.tags);
-      } catch (e) {
-        // If parsing fails, initialize with empty array
-        this._tagsArray = [];
-      }
-    } else {
-      this._tagsArray = [];
-    }
-  }
 } 

--- a/src/main/services/importLibrary.ts
+++ b/src/main/services/importLibrary.ts
@@ -101,7 +101,7 @@ export async function importLibrary(
             fingerprint: patchFingerprint,
             default_patch: false,
             favorited: false,
-            tagsArray: tags
+            tags
           });
         } else {
           // Create default patch
@@ -112,7 +112,7 @@ export async function importLibrary(
             fingerprint: createHash('sha256').update(`${patchBank.id}-${patchNum}`).digest('hex'),
             default_patch: true,
             favorited: false,
-            tags: ''
+            tags: []
           });
         }
         await patchRepo.save(patch);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -164,14 +164,14 @@ const App: React.FC = () => {
   const handlePatchTagRemove = async (patchId: string, tagToRemove: string) => {
     const patch = patches.find(p => p.id.toString() === patchId);
     if (patch) {
-      const currentTags = JSON.parse(patch.tags || '[]');
+      const currentTags = patch.tags || [];
       const updatedTags = currentTags.filter((tag: string) => tag !== tagToRemove);
       try {
-        await window.electronAPI.updatePatch(patchId, { tags: JSON.stringify(updatedTags) });
+        await window.electronAPI.updatePatch(patchId, { tags: updatedTags });
         setPatches(patches.map(p => {
           if (p.id.toString() === patchId) {
             const updatedPatch = new Patch();
-            Object.assign(updatedPatch, p, { tags: JSON.stringify(updatedTags) });
+            Object.assign(updatedPatch, p, { tags: updatedTags });
             return updatedPatch;
           }
           return p;
@@ -185,15 +185,15 @@ const App: React.FC = () => {
   const handlePatchTagAdd = async (patchId: string, newTag: string) => {
     const patch = patches.find(p => p.id.toString() === patchId);
     if (patch) {
-      const currentTags = JSON.parse(patch.tags || '[]');
+      const currentTags = patch.tags || [];
       if (!currentTags.includes(newTag)) {
         const updatedTags = [...currentTags, newTag];
         try {
-          await window.electronAPI.updatePatch(patchId, { tags: JSON.stringify(updatedTags) });
+          await window.electronAPI.updatePatch(patchId, { tags: updatedTags });
           setPatches(patches.map(p => {
             if (p.id.toString() === patchId) {
               const updatedPatch = new Patch();
-              Object.assign(updatedPatch, p, { tags: JSON.stringify(updatedTags) });
+              Object.assign(updatedPatch, p, { tags: updatedTags });
               return updatedPatch;
             }
             return p;
@@ -257,7 +257,7 @@ const App: React.FC = () => {
             patches={patches.map(patch => ({
               id: patch.id.toString(),
               name: capitalizeWords(patch.name),
-              tags: JSON.parse(patch.tags || '[]'),
+              tags: patch.tags || [],
               favorited: patch.favorited,
               selected: selectedPatches.has(patch.id.toString())
             }))}


### PR DESCRIPTION
## Summary
- simplify Patch.tags to use `simple-json`
- update importLibrary to handle tag arrays directly
- update renderer logic for new tags type
- adjust App tests for tags array

## Testing
- `npm run lint:fix`
- `NODE_ENV=test npm test` *(fails: cannot read properties during test execution)*

------
https://chatgpt.com/codex/tasks/task_e_684f0de0fdc483268e7e181f3ef99450